### PR TITLE
Updated includes to match newer okcupid URLs and HTTPS

### DIFF
--- a/OkCupid-Autolike.user.js
+++ b/OkCupid-Autolike.user.js
@@ -2,6 +2,11 @@
 // @name OkCupid-Autolike-Autolike
 // @author nemanjan00
 // @include http://www.okcupid.com/quickmatch
+// @include https://www.okcupid.com/quickmatch
+// @include http://www.okcupid.com/doubletake
+// @include https://www.okcupid.com/doubletake
+// @include https://www2.okcupid.com/doubletake
+// @include https://www2.okcupid.com/quickmatch
 // @downloadURL https://raw.githubusercontent.com/nemanjan00/OkCupid-Autolike/master/OkCupid-Autolike.user.js
 // @namespace https://github.com/nemanjan00/OkCupid-Autolike
 // @updateURL https://raw.githubusercontent.com/nemanjan00/OkCupid-Autolike/master/OkCupid-Autolike.user.js

--- a/OkCupid-Autolike.user.js
+++ b/OkCupid-Autolike.user.js
@@ -10,7 +10,7 @@
 // @downloadURL https://raw.githubusercontent.com/nemanjan00/OkCupid-Autolike/master/OkCupid-Autolike.user.js
 // @namespace https://github.com/nemanjan00/OkCupid-Autolike
 // @updateURL https://raw.githubusercontent.com/nemanjan00/OkCupid-Autolike/master/OkCupid-Autolike.user.js
-// @version 2
+// @version 2.1
 // ==/UserScript==
 
 setInterval(function(){


### PR DESCRIPTION
They changed the name from quick match to doubletake. I also added https compatibility and for they're mirror websites(www2).